### PR TITLE
PTB support and fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,19 @@ Unofficial RPM package for Discord.
 ## How to use
 1. [Download](https://github.com/RPM-Outpost/discord/archive/master.zip) and extract the zip.
 2. Open a terminal and `cd` to the `discord-master` directory.
-3. Run `./create-package.sh stable` to get the stable version of Discord, or `./create-package.sh canary` to get the unstable beta version.
+3. Run one of the following depending on the version you want to create a package for:
+    - Discord Stable: `./create-package.sh stable`
+    - Discord PTB: &nbsp;&nbsp;&nbsp; `./create-package.sh ptb`
+    - Discord Canary: `./create-package.sh canary`
 
 ## Features
 - Downloads the latest version of Discord from the official website
 - Creates a ready-to-use RPM package
-- Discord stable and canary can be installed at the same time
-- Adds Discord to the applications' list with a nice HD icon
+- Discord Stable, PTB, and Canary can be installed at the same time
+- Adds Discord to the applications list with a nice HD icon
 - Supports Fedora (26, 27), OpenSUSE (Leap) and CentOS (7.x)
 
-## More informations
+## More information
 
 ### Warning - no accents
 
@@ -23,9 +26,9 @@ The path where you run the script must **not** contain any special character lik
 
 ### How to update
 
-When a new version of discord is released, simply run the script again to get the updated version.
+When a new version of Discord is released, simply run the script again to get the updated version.
 
-### Requirements
+### Dependencies
 The `rpmdevtools` package is required to build RPM packages. The script detects if it isn't installed and offers to install it.
 
 ### About root privileges

--- a/common-functions.sh
+++ b/common-functions.sh
@@ -26,8 +26,17 @@ else
 	distrib="unknown"
 fi
 
-# Initializes $wget_progress: detects if the option --show-progress is available
-wget --help | grep -q '\--show-progress' && wget_progress="-q --show-progress" || wget_progress=""
+# Initializes $downloader: checks if wget is installed and fallbacks to curl if it isn't
+hash wget 2>/dev/null && downloader='wget' || downloader='curl'
+
+# Initializes $progress: detects if the downloader has a progress option
+if [[ "$downloader" == 'wget' ]]; then
+    wget --help | grep -q '\--show-progress' && \
+	  progress='-q --show-progress' || progress=''
+else
+    curl --help | grep -q '\--progress-bar' && \
+      progress='--progress-bar' || progress=''
+fi
 
 # ask_yesno question
 ## Asks a yes/no question and stores the result in the 'answer' variable
@@ -58,7 +67,7 @@ ask_remove_dir() {
 ## If it doesn't exist, creates it.
 manage_dir() {
 	if [ -d "$1" ]; then
-		echo "The $2 directory already exist and may contain outdated data."
+		echo "The $2 directory already exists and may contain outdated data."
 		ask_remove_dir "$1"
 	fi
 	mkdir -p "$1"

--- a/discord.spec
+++ b/discord.spec
@@ -5,7 +5,7 @@
 # downloaded_dir
 # desktop_file
 
-%define install_dir /opt/discord-stable
+%define install_dir /opt/%{pkg_name}
 %define apps_dir /usr/share/applications
 %define _build_id_links none
 


### PR DESCRIPTION
## Additions:
- Support for Discord PTB
- Fallback to `curl` when `wget` is not installed

## Fixes:
- Installation directory being `/opt/discord-stable` regardless of version
- Script exiting with 0 on error

## Misc:
- Updated documentation 
- Removed suffix from the Stable installation
- Some minor edits

## Testing environment:
- **Distribution:** Fedora 27 KDE
- **rpmbuild:** RPM version 4.14.1
- **Discord:** 
  - Stable 0.0.4
  - PTB 0.0.7
  - Canary 0.0.45
