### PR TITLE
Specifically set the Discord binary to be executable

### DIFF
--- a/discord.spec
+++ b/discord.spec
@@ -34,6 +34,7 @@ mkdir -p "%{buildroot}%{apps_dir}"
 mv "%{downloaded_dir}"/* "%{buildroot}%{install_dir}"
 cp "%{desktop_file}" "%{buildroot}%{apps_dir}"
 chmod +x "%{buildroot}%{install_dir}"/*.so
+chmod +x "%{buildroot}%{install_dir}"/Discord*
 
 %files
 %{install_dir}


### PR DESCRIPTION
At some point, the Discord binary provided by Discord had its default permissions changed. As a result,  this script creates a broken RPM that installs an unexecutable binary, meaning the user cannot launch Discord until the user specifically `chmod +x`s the `Discord(PTB/Canary)` binary in `/opt/discord(-ptb/canary)`. This PR adds this command to the spec file so manual intervention by the user is no longer necessary.