### PR TITLE
Add Discord Development Branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,12 @@ Unofficial RPM package for Discord.
     - Discord Stable: `./create-package.sh stable`
     - Discord PTB: &nbsp;&nbsp;&nbsp; `./create-package.sh ptb`
     - Discord Canary: `./create-package.sh canary`
+    - Discord Development: `./create-package.sh development`
 
 ## Features
 - Downloads the latest version of Discord from the official website
 - Creates a ready-to-use RPM package
-- Discord Stable, PTB, and Canary can be installed at the same time
+- Discord Stable, PTB, Canary, and Development can be installed at the same time
 - Adds Discord to the applications list with a nice HD icon
 - Supports Fedora (31) and OpenSUSE (Leap 15.1+).
 

--- a/create-package.sh
+++ b/create-package.sh
@@ -24,9 +24,9 @@ else
 fi	
 
 # Checks that the version (stable/ptb/canary) is given as a parameter.
-if [[ $# -ne 1 || $1 != "stable" && $1 != "ptb" && $1 != "canary" ]]; then
+if [[ $# -ne 1 || $1 != "stable" && $1 != "ptb" && $1 != "canary" && $1 != "development" ]]; then
 	disp "${red}Wrong or missing parameters!$reset"
-	echo 'Usage: create-package.sh [ stable | ptb | canary ]'
+	echo 'Usage: create-package.sh [ stable | ptb | canary | development ]'
 	exit 1
 fi
 
@@ -45,6 +45,13 @@ elif [[ $1 == "ptb" ]]; then
 	download_url='https://discordapp.com/api/download/ptb'
 	cut_part=3
 	desktop_file="$work_dir/discord-ptb.desktop"
+elif [[ $1 == "development" ]]; then
+        app_name='Discord Development'
+        exe_name='DiscordDevelopment'
+        pkg_name='discord-development'
+        download_url='https://discordapp.com/api/download/development'
+        cut_part=3
+        desktop_file="$work_dir/discord-development.desktop"
 else
 	app_name='Discord'
 	exe_name='Discord'


### PR DESCRIPTION
This allows the development branch to be installed. Pulling from https://discordapp.com/api/download/development

As far as i can see this is just canary, but can be used as a separate instance.