### PR TITLE
Fix package dependencies for RedHat derived distros

### DIFF
--- a/create-package.sh
+++ b/create-package.sh
@@ -15,7 +15,7 @@ arch='x86_64'
 
 # Settings according to the distribution
 if [[ $distrib == "redhat" ]]; then
-	pkg_req='libatomic%{?_isa}, glibc%{?_isa}, alsa-lib%{?_isa}, GConf2%{?_isa}, libnotify%{?_isa}, nspr%{?_isa} >= 4.13, nss%{?_isa} >= 3.27, libstdc++%{?_isa}, libX11%{?_isa} >= 1.6, libXtst%{?_isa} >= 1.2, libappindicator%{?_isa}, libcxx%{?_isa}, libXScrnSaver%{?_isa}'
+	pkg_req='libatomic%{?_isa}, glibc%{?_isa}, alsa-lib%{?_isa}, GConf2%{?_isa}, libnotify%{?_isa}, nspr%{?_isa} >= 4.13, nss%{?_isa} >= 3.27, libstdc++%{?_isa}, libX11%{?_isa} >= 1.6, libXtst%{?_isa} >= 1.2, libappindicator-gtk3%{?_isa}, libXScrnSaver%{?_isa}'
 elif [[ $distrib == "suse" ]]; then
 	pkg_req='libatomic1, glibc, alsa, gconf2, libnotify, mozilla-nspr >= 4.13, mozilla-nss >= 3.27, libstdc++6, libX11 >= 1.6, libXtst >= 1.2, libappindicator, libc++1, libXScrnSaver'
 else


### PR DESCRIPTION
When the package is built with the original dependencies, it won't install cleanly.
```
# rpm -Uvh discord-0.0.20-2.el8.x86_64.rpm 
error: Failed dependencies:
	libappindicator(x86-64) is needed by discord-0.0.20-2.el8.x86_64
	libcxx(x86-64) is needed by discord-0.0.20-2.el8.x86_64
```

This small patch fixes the dependency naming for what is used on at least EL8 and EL9 (test on both of those).