### PR TITLE
Make create-package.sh runnable from any directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Unofficial RPM package for Discord.
     - Discord Canary: `./create-package.sh canary`
     - Discord Development: `./create-package.sh development`
 
+Alternatively, you can call `discord-master/create-package.sh` directly, without changing your working directory.
+
 ## Features
 - Downloads the latest version of Discord from the official website
 - Creates a ready-to-use RPM package

--- a/create-package.sh
+++ b/create-package.sh
@@ -2,6 +2,16 @@
 # Author: TheElectronWill
 # This script downloads the latest version of Discord for linux, and creates a package with rpmbuild.
 
+# Jump to the script's directory.
+# Taken from # https://stackoverflow.com/a/246128/1667018 # and slightly modified.
+SOURCE="${BASH_SOURCE[0]}"
+while [ -L "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ "$SOURCE" != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+cd "$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
+
 source terminal-colors.sh # Adds color variables
 source common-functions.sh # Adds utilities functions
 source basic-checks.sh # Checks that rpmbuild is available and that the script isn't started as root


### PR DESCRIPTION
The original `create-package.sh` requires the user to `cd` into project directory. This PR adds some code that detects that directory and automatically jumps there before anything else is done, thus allowing users to call the script directly from any directory.